### PR TITLE
fix(phantom-host-lib): 插件安装时拷贝 so 不完整

### DIFF
--- a/phantom-host-lib/src/main/java/com/wlqq/phantom/library/pm/NativeLibraryUtils.java
+++ b/phantom-host-lib/src/main/java/com/wlqq/phantom/library/pm/NativeLibraryUtils.java
@@ -101,6 +101,7 @@ final class NativeLibraryUtils {
      * @param zipFile          APK file to scan for native libraries
      * @param sharedLibraryDir directory for libraries to be copied to
      * @param abi              device abi type
+     * @return copy so successfully
      * @throws CopyNativeSoException 拷贝 so 失败
      * @see #ABI_ARMEABI
      * @see #ABI_ARMEABI_V7A
@@ -112,6 +113,7 @@ final class NativeLibraryUtils {
      */
     static boolean copyNativeBinaries(@NonNull ZipFile zipFile, @NonNull File sharedLibraryDir, @NonNull String abi)
             throws CopyNativeSoException {
+        int copiedSoCount = 0;
         try {
             Enumeration<? extends ZipEntry> entries = zipFile.entries();
             while (entries.hasMoreElements()) {
@@ -125,10 +127,10 @@ final class NativeLibraryUtils {
                     final File destination = new File(sharedLibraryDir, soName);
                     VLog.w("copy from %s to %s", name, destination);
                     FileUtils.copyInputStreamToFile(zipFile.getInputStream(entry), destination);
-                    return true;
+                    copiedSoCount++;
                 }
             }
-            return false;
+            return copiedSoCount > 0;
         } catch (IOException e) {
             final String msg = "copyNativeBinaries error, abi: " + abi;
             VLog.w(e, msg);

--- a/phantom-sample/host/build.gradle
+++ b/phantom-sample/host/build.gradle
@@ -70,3 +70,12 @@ dependencies {
 
     implementation 'com.tencent.bugly:crashreport_upgrade:1.1.7'
 }
+
+
+// uncomment the following line to use the latest phantom-host-lib source code to build sample
+//
+//configurations.all {
+//    resolutionStrategy.dependencySubstitution {
+//        substitute module("com.wlqq.phantom:phantom-host-lib:${phantomVersion.hostLib}") with project(":phantom-host-lib")
+//    }
+//}

--- a/phantom-sample/plugin-component/build.gradle
+++ b/phantom-sample/plugin-component/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     compileOnly "com.wlqq.phantom:phantom-communication-lib:${phantomVersion.communicationLib}"
     compileOnly "com.wlqq.phantom:phantom-plugin-lib:${phantomVersion.pluginLib}"
 
+    implementation 'tv.danmaku.ijk.media:ijkplayer-java:0.8.8'
+    implementation 'tv.danmaku.ijk.media:ijkplayer-armv7a:0.8.8'
+
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "com.android.support:support-v4:${androidVersion.supportLib}"
     implementation 'io.github.shaobin0604:awesomelog:1.0.1'


### PR DESCRIPTION
只拷贝了插件的中一个 so

root cause:
在循环中拷贝了一个 so 就通过 return 退出了方法

how to fix:
在循环拷贝 so 时通过 copiedSoCount 变量记录拷贝 so 的数量，若该变量
值大于零，则说明有拷贝 so ，方法返回 true ，否则返回 false

测试影响：
包含多个 so 的插件安装